### PR TITLE
Eliminating false botshot results by navigating to about:blank

### DIFF
--- a/botshot.py
+++ b/botshot.py
@@ -79,6 +79,7 @@ def webshot(args):
         outfile = outdir + "/" + p.sub("_", url) + ".png"
 
         try:
+            browser.get("about:blank")
             browser.get(url)
             time.sleep(1) # workaround for some targets
             browser.save_screenshot(outfile)


### PR DESCRIPTION
`botsot.py` takes false screenshots if an unreachable URL exists in the input URL list. To test, fire up a local python webserver:

```
python -m SimpleHTTPServer
```

This will serve on :8000. Create an input file containing the following URL's:

```
http://127.0.0.1:8000
http://127.0.0.1:8001
```

Run botshot with the above input. As you will see, the result of port 8001 will be the same as the one for the python webserver (assuming there is nothing running on port 8001 locally). This is (probably) because Selenium stores the last recorded screen, but doesn't throw an exception on connection failure.

This patch offers a naive solution by always navigating to about:blank first. Apparently this clears Selenium's screen buffer, and yields appropriate results.